### PR TITLE
JSDK-2528: option to use circleci as CI environment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,37 +12,27 @@ parameters:
     default: false
   releaseCommand:
     type: string
-    default: "foo" # when specified this mean the workflow was called from release-tool.
+    default: "echo no release command was specified" # release-tool specifies the real command.
 executors:
   generic-executor:
     docker:
       - image: 'circleci/node:latest'
+
+
 jobs:
   ExecuteRelease:
     executor: generic-executor
-    parameters:
-      releaseCommand:
-        type: string
-        default: ""
     steps:
       - checkout # release command builds as part of the flow.
-      - run: echo <<pipeline.parameters.releaseCommand>>
-      # - run: <<parameters.releaseCommand>>
-      #     type: approval
-  EchoJob:
+      - run: << pipeline.parameters.releaseCommand >>
+  PrJob:
     executor: generic-executor
-    parameters:
-      to:
-        type: string
-        default: "Hello World"
     steps:
-      - run: echo << parameters.to >>
+      - run: echo This is a placeholder for PR job
   ExecuteReleaseDummy:
     executor: generic-executor
     steps:
-      - run: echo relasecommand = << pipeline.parameters.releaseCommand >>
-      - run: echo GH_TOKEN=$GH_TOKEN
-      - run: echo NPM_AUTH_TOKEN=$NPM_AUTH_TOKEN
+      - run: echo Will execute "<< pipeline.parameters.releaseCommand >>"
 
 
 workflows:
@@ -50,20 +40,15 @@ workflows:
   PR_Workflow:
     when: << pipeline.parameters.pr_workflow >>
     jobs:
-      - EchoJob:
-          to: "This is my placeholder PR job"
+      - PrJob
   Release_Workflow:
     when: << pipeline.parameters.release_workflow >>
     jobs:
-      - hold1:
-          type: approval
       - ExecuteReleaseDummy:
           context: sdk_js
-          requires: [hold1]
-      - hold2:
+      - hold:
           type: approval
           requires: [ExecuteReleaseDummy]
       - ExecuteRelease: # this job has conditional steps, no-ops when pipeline.parameters.releaseCommand not specified
           context: sdk_js
-          releaseCommand: << pipeline.parameters.releaseCommand >>
-          requires: [hold2]
+          requires: [hold]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,8 @@ jobs:
   ExecuteRelease:
     executor: generic-executor
     steps:
-      - checkout # release command builds as part of the flow.
+      - checkout
+      - run: npm install
       - run: << pipeline.parameters.releaseCommand >>
   PrJob:
     executor: generic-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,6 @@
 # use:
 # circleci config process .circleci/config.yml > config_processed.yml
 #
-# and run any job locally with:
-# circleci local execute -c config_processed.yml --job "firefox stable group"
 version: 2.1
 parameters:
   pr_workflow:    # runs for every pull request.
@@ -39,6 +37,13 @@ jobs:
         default: "Hello World"
     steps:
       - run: echo << parameters.to >>
+  ExecuteReleaseDummy:
+    executor: generic-executor
+    steps:
+      - run: echo relasecommand = << pipeline.parameters.releaseCommand >>
+      - run: echo GH_TOKEN=$GH_TOKEN
+      - run: echo NPM_AUTH_TOKEN=$NPM_AUTH_TOKEN
+
 
 workflows:
   version: 2
@@ -50,8 +55,15 @@ workflows:
   Release_Workflow:
     when: << pipeline.parameters.release_workflow >>
     jobs:
-      - hold:
+      - hold1:
           type: approval
+      - ExecuteReleaseDummy:
+          context: sdk_js
+          requires: [hold1]
+      - hold2:
+          type: approval
+          requires: [ExecuteReleaseDummy]
       - ExecuteRelease: # this job has conditional steps, no-ops when pipeline.parameters.releaseCommand not specified
+          context: sdk_js
           releaseCommand: << pipeline.parameters.releaseCommand >>
-          requires: [hold]
+          requires: [hold2]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,57 @@
+# to validate any changes
+# use:
+# circleci config process .circleci/config.yml > config_processed.yml
+#
+# and run any job locally with:
+# circleci local execute -c config_processed.yml --job "firefox stable group"
+version: 2.1
+parameters:
+  pr_workflow:    # runs for every pull request.
+    type: boolean
+    default: true # by default pr workflow will get executed.
+  release_workflow:
+    type: boolean
+    default: false
+  releaseCommand:
+    type: string
+    default: "foo" # when specified this mean the workflow was called from release-tool.
+executors:
+  generic-executor:
+    docker:
+      - image: 'circleci/node:latest'
+jobs:
+  ExecuteRelease:
+    executor: generic-executor
+    parameters:
+      releaseCommand:
+        type: string
+        default: ""
+    steps:
+      - checkout # release command builds as part of the flow.
+      - run: echo <<pipeline.parameters.releaseCommand>>
+      # - run: <<parameters.releaseCommand>>
+      #     type: approval
+  EchoJob:
+    executor: generic-executor
+    parameters:
+      to:
+        type: string
+        default: "Hello World"
+    steps:
+      - run: echo << parameters.to >>
+
+workflows:
+  version: 2
+  PR_Workflow:
+    when: << pipeline.parameters.pr_workflow >>
+    jobs:
+      - EchoJob:
+          to: "This is my placeholder PR job"
+  Release_Workflow:
+    when: << pipeline.parameters.release_workflow >>
+    jobs:
+      - hold:
+          type: approval
+      - ExecuteRelease: # this job has conditional steps, no-ops when pipeline.parameters.releaseCommand not specified
+          releaseCommand: << pipeline.parameters.releaseCommand >>
+          requires: [hold]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/.release.json
+++ b/.release.json
@@ -1,6 +1,6 @@
 {
   "type": "JavaScript",
-  "noci": "circleci",
+  "ci": "circleci",
   "slug": "twilio/release-tool",
   "env": {
     "GH_REF": "github.com/twilio/release-tool.git"

--- a/.release.json
+++ b/.release.json
@@ -1,9 +1,9 @@
 {
   "type": "JavaScript",
-  "travis": true,
-  "slug": "markandrus/release-tool",
+  "ci": "circleci",
+  "slug": "twilio/release-tool",
   "env": {
-    "GH_REF": "github.com/markandrus/release-tool.git"
+    "GH_REF": "github.com/twilio/release-tool.git"
   },
   "plans": {
     "release": {

--- a/.release.json
+++ b/.release.json
@@ -1,6 +1,6 @@
 {
   "type": "JavaScript",
-  "ci": "circleci",
+  "noci": "circleci",
   "slug": "twilio/release-tool",
   "env": {
     "GH_REF": "github.com/twilio/release-tool.git"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ ./node_modules/.bin/release --help
     -n, --non-interactive  run in non-interactive mode (e.g., in a script)
     -p, --publish          execute the publish plan
     -s, --slug             specify the repository slug (owner_name/repo_name)
-    -t, --token            assign the Travis CI token to use
+    -t, --token            assign the CI token to use
     -x, --execute          execute the plans (defaults to true unless using Travis CI)
 
 ```
@@ -78,6 +78,7 @@ version number must be bumped before committing the Software.
 {
   "type": "JavaScript",
   "travis": true,
+  "ci": "travis",
   "slug": "markandrus/release-tool",
   "env": {
     "GH_REF": "github.com/markandrus/release-tool.git"

--- a/README.md
+++ b/README.md
@@ -77,11 +77,10 @@ version number must be bumped before committing the Software.
 ```json
 {
   "type": "JavaScript",
-  "travis": true,
-  "ci": "travis",
-  "slug": "markandrus/release-tool",
+  "ci": "circleci",
+  "slug": "twilio/release-tool",
   "env": {
-    "GH_REF": "github.com/markandrus/release-tool.git"
+    "GH_REF": "github.com/twilio/release-tool.git"
   },
   "plans": {
     "release": {
@@ -124,12 +123,11 @@ unassigned variables referenced in a plan's commands can be overridden by the
 environment or command-line arguments. All other assigned variables are fixed
 and cannot be overridden except in the .release.json itself.
 
-Travis CI
+Travis CI Or CircleCI
 ---------
 
-If you set the property "travis" to `true` in the top-level of your software's
+If you set the property `ci` to `travis` or `circleci` in the top-level of your software's
 .release.json, then the tool will not execute any plans locally; instead, it
-will POST a request to Travis CI in order to execute the plans. You can also
-set the property to "pro".
+will POST a request to Travis CI  or CircleCi in order to execute the plans.
 
 Be very careful not to leak any sensitive data.

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -15,7 +15,7 @@ function triggerBuild(program) {
 }
 function setCIEnvironment(config) {
   // eslint-disable-next-line no-undefined
-  if (!config.ci || !config.travis) {
+  if (!config.ci && !config.travis) {
       // no CI environment specified.
       return;
   }
@@ -28,6 +28,8 @@ function setCIEnvironment(config) {
   if (!['travis', 'circleci'].includes(config.ci)) {
     throw new Error('only "circleci" or "travis" are valid values for ci. Found: ' + config.ci);
   }
+
+  console.log('Setting ci environment: ', config.ci);
   ciEnvironment = config.ci;
 }
 

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -10,9 +10,9 @@ function triggerBuild(program) {
   } else if (ciEnvironment === 'circleci') {
     return circleci.triggerBuild(program);
   }
-
   throw new Error('unsupported CI environment:' + program.ci);
 }
+
 function setCIEnvironment(config) {
   // eslint-disable-next-line no-undefined
   if (!config.ci && !config.travis) {

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const travis = require('./travis');
+const circleci = require('./circleci');
+let ciEnvironment;
+
+function triggerBuild(program) {
+  if (ciEnvironment === 'travis') {
+    return travis.triggerBuild(program);
+  } else if (ciEnvironment === 'circleci') {
+    return circleci.triggerBuild(program);
+  }
+
+  throw new Error('unsupported CI environment:' + program.ci);
+}
+function setCIEnvironment(config) {
+  // eslint-disable-next-line no-undefined
+  if (!config.ci || !config.travis) {
+      // no CI environment specified.
+      return;
+  }
+
+  // old style ci environment?
+  if (config.travis) {
+    config.ci = 'travis';
+  }
+
+  if (!['travis', 'circleci'].includes(config.ci)) {
+    throw new Error('only "circleci" or "travis" are valid values for ci. Found: ' + config.ci);
+  }
+  ciEnvironment = config.ci;
+}
+
+module.exports = {
+  triggerBuild,
+  setCIEnvironment
+};
+

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 
 const travis = require('./travis');
@@ -14,7 +15,6 @@ function triggerBuild(program) {
 }
 
 function setCIEnvironment(config) {
-  console.log(config);
   // eslint-disable-next-line no-undefined
   if (!config.ci && !config.travis) {
       // no CI environment specified.

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -14,6 +14,7 @@ function triggerBuild(program) {
 }
 
 function setCIEnvironment(config) {
+  console.log(config);
   // eslint-disable-next-line no-undefined
   if (!config.ci && !config.travis) {
       // no CI environment specified.

--- a/lib/circleci.js
+++ b/lib/circleci.js
@@ -1,12 +1,13 @@
+/* eslint-disable camelcase */
 /* eslint-disable no-console */
 'use strict';
-// 'NzY1ZmViOWM5Yzg4ZDdkZGI5N2U4Yzg4ZWFiOGFmMjUzM2YzOGI3NDo='
 var http = require('https');
+
 function triggerBuild(program) {
   return new Promise(function triggerBuildPromise(resolve, reject) {
     var options = {
       hostname: 'circleci.com',
-      path: '/api/v2/project/github/' + program.slug + '/pipeline',
+      path: `/api/v2/project/github/${program.slug}/pipeline`,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -27,9 +28,7 @@ function triggerBuild(program) {
     const body = {
       branch: program.branch,
       parameters: {
-        // eslint-disable-next-line camelcase
-        run_release_steps: true,
-        stability: 'stable',
+        release_workflow: true,
         releaseCommand
       }
     };

--- a/lib/circleci.js
+++ b/lib/circleci.js
@@ -1,29 +1,39 @@
 /* eslint-disable camelcase */
 /* eslint-disable no-console */
 'use strict';
-var http = require('https');
+
+const http = require('https');
 
 function triggerBuild(program) {
   return new Promise(function triggerBuildPromise(resolve, reject) {
-    var options = {
+    const {
+      slug,
+      token,
+      branch,
+      currentVersion,
+      publish,
+      releaseVersion,
+      developmentVersion
+    } = program;
+
+    const options = {
       hostname: 'circleci.com',
-      path: `/api/v2/project/github/${program.slug}/pipeline`,
+      path: `/api/v2/project/github/${slug}/pipeline`,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Basic ' + new Buffer(program.token).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(token).toString('base64'),
         'Accept': 'application/json',
         'Host': 'circleci.com',
       }
     };
 
-    const releaseCommand = './node_modules/.bin/release -b ' + program.branch +
-        ' -n' +
-        (program.publish ? ' -p' : '') +
-        ' -x ' +
-        program.currentVersion + ' ' +
-        program.releaseVersion +
-        (program.developmentVersion ? ' ' + program.developmentVersion : '');
+    const releaseCommand = './node_modules/.bin/release -n -x '
+      + ` -b ${branch}`
+      + ` ${publish ? '-p' : ''}`
+      + ` ${currentVersion}`
+      + ` ${releaseVersion}`
+      + developmentVersion ? ` ${developmentVersion}` : '';
 
     const body = {
       branch: program.branch,
@@ -38,7 +48,7 @@ function triggerBuild(program) {
       const chunks = [];
       res.on('data', chunk => chunks.push(chunk));
       res.on('end', () => {
-        var resBody = Buffer.concat(chunks);
+        const resBody = Buffer.concat(chunks);
         resolve(resBody.toString());
       });
     });

--- a/lib/circleci.js
+++ b/lib/circleci.js
@@ -1,0 +1,53 @@
+'use strict';
+// 'NzY1ZmViOWM5Yzg4ZDdkZGI5N2U4Yzg4ZWFiOGFmMjUzM2YzOGI3NDo='
+var http = require('https');
+function triggerBuild(program) {
+  return new Promise(function triggerBuildPromise(resolve, reject) {
+    var options = {
+      hostname: 'circleci.com',
+      path: '/api/v2/project/github/' + encodeURIComponent(program.slug) + '/pipeline',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Basic ' + program.token,
+        'Accept': 'application/json',
+        'Host': 'circleci.com',
+      }
+    };
+
+    const releaseCommand = './node_modules/.bin/release -b ' + program.branch +
+        ' -n' +
+        (program.publish ? ' -p' : '') +
+        ' -x ' +
+        program.currentVersion + ' ' +
+        program.releaseVersion +
+        (program.developmentVersion ? ' ' + program.developmentVersion : '');
+
+    const body = {
+      branch: program.branch,
+      parameters: {
+        // eslint-disable-next-line camelcase
+        run_release_steps: true,
+        stability: 'stable',
+        releaseCommand
+      }
+    };
+
+    const request = http.request(options, function(res) {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => {
+        var resBody = Buffer.concat(chunks);
+        // eslint-disable-next-line no-console
+        console.log(resBody.toString());
+        resolve(resBody.toString());
+      });
+    });
+
+    request.once('error', reject);
+    request.end(JSON.stringify(body));
+  });
+}
+
+
+module.exports.triggerBuild = triggerBuild;

--- a/lib/circleci.js
+++ b/lib/circleci.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 'use strict';
 // 'NzY1ZmViOWM5Yzg4ZDdkZGI5N2U4Yzg4ZWFiOGFmMjUzM2YzOGI3NDo='
 var http = require('https');
@@ -5,11 +6,11 @@ function triggerBuild(program) {
   return new Promise(function triggerBuildPromise(resolve, reject) {
     var options = {
       hostname: 'circleci.com',
-      path: '/api/v2/project/github/' + encodeURIComponent(program.slug) + '/pipeline',
+      path: '/api/v2/project/github/' + program.slug + '/pipeline',
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Basic ' + program.token,
+        'Authorization': 'Basic ' + new Buffer(program.token).toString('base64'),
         'Accept': 'application/json',
         'Host': 'circleci.com',
       }
@@ -33,13 +34,12 @@ function triggerBuild(program) {
       }
     };
 
+    console.log('Making a CI request with:', options, body);
     const request = http.request(options, function(res) {
       const chunks = [];
       res.on('data', chunk => chunks.push(chunk));
       res.on('end', () => {
         var resBody = Buffer.concat(chunks);
-        // eslint-disable-next-line no-console
-        console.log(resBody.toString());
         resolve(resBody.toString());
       });
     });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var commander = require('commander');
-var constants = require('./constants');
-var env = require('./env');
 
 /**
  * Assert that the program contains a valid number of arguments.
@@ -27,6 +25,7 @@ function assertValidArgumentCount(program) {
  * @throws {Error}
  */
 function cli(process, pkg, config) {
+  const ci = config.ci || 'Travis';
   var program = commander
     .version(pkg.version)
     .description(
@@ -44,11 +43,8 @@ function cli(process, pkg, config) {
     .option('-p, --publish', 'execute the publish plan')
     .option('-s, --slug', 'specify the repository slug ' +
                           '(owner_name/repo_name)')
-    .option('-t, --token', 'assign the Travis CI token to use')
-    .option('-x, --execute', 'execute the plans (defaults to true unless using Travis CI)')
-
-  // env.addCommandLineOptionsForVariablesUnassignedInConfigPlans(program, config,
-  //   constants.excluding);
+    .option('-t, --token', `assign the ${ci} token to use`)
+    .option('-x, --execute', `execute the plans (defaults to true unless using ${ci} CI)`);
 
   program = program.parse(process.argv);
   assertValidArgumentCount(program);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+/* eslint-disable no-process-env */
 'use strict';
 
 var bump = require('./bump');
@@ -10,7 +12,7 @@ var os = require('os');
 var pkg = require('../package');
 var readConfig = require('./config');
 var semver = require('semver');
-var travis = require('./travis');
+var ci = require('./ci');
 var ui = require('./ui');
 var util = require('./util');
 var version = require('./version');
@@ -191,19 +193,19 @@ function getSlug(program, config) {
     }, slug).then(function setSlug(slug) {
       program.slug = slug;
     });
-} 
+}
 
 function getToken(program) {
   if (program.token) {
     return Promise.resolve(program.token);
   } else if (program.nonInteractive) {
-    return Promise.reject(new Error('A Travis CI token is required'));
+    return Promise.reject(new Error(`A ${program.ci} CI token is required`));
   }
   return ui.password(
-      'Travis CI token:',
+      `${program.ci} CI token:`,
       function validateToken(token) {
         if (!token.length) {
-          throw new Error('A Travis CI token is required');
+          throw new Error(`A ${program.ci} CI token is required`);
         }
       }
     ).then(function setToken(token) {
@@ -227,15 +229,13 @@ function getVersions(process, program, root, constants) {
 function run(process) {
   var config;
   var constants = new Map();
-  var currentVersion;
-  var developmentVersion;
   var plans;
   var plansToExecute;
   var program;
-  var releaseOrReleaseCandidateVersion;
   var root = process.cwd();
   return new Promise(function runPromise(resolve) {
       config = readConfig(root);
+      ci.setCIEnvironment(config);
       program = cli(process, pkg, config);
 
       git.assertNoUncommittedChanges(root);
@@ -291,7 +291,7 @@ function run(process) {
           var planName = pair[1];
           var plan = plans.get(planName);
           if (!plan) {
-            throw new Error("Plan '" + planName + "' does not exist");
+            throw new Error('Plan \'' + planName + '\' does not exist');
           }
           if (!program.nonInteractive) {
             console.log('\n  %s:\n', colors.bold(pair[0]));
@@ -315,7 +315,7 @@ function run(process) {
               throw new Error('User aborted release');
             }
 
-            if (!config.travis || program.execute) {
+            if (!config.ci || program.execute) {
               return plansToExecute.map(function bindVariables(pair) {
                 var variables = env.getVariablesForConfigPlan(program, config,
                   pair[0], constants, process);
@@ -332,12 +332,13 @@ function run(process) {
               });
             }
 
-            program.travis = config.travis;
+            program.ci = config.ci;
 
             return getSlug(program, config)
               .then(getToken.bind(null, program))
-              .then(travis.triggerBuild.bind(null, program))
+              .then(ci.triggerBuild.bind(null, program))
               .then(function withResponse(response) {
+                // eslint-disable-next-line no-warning-comments
                 // TODO(mroberts): Make pretty
                 console.log(response);
               });

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,20 +2,20 @@
 /* eslint-disable no-process-env */
 'use strict';
 
-var bump = require('./bump');
-var cli = require('./cli');
-var colors = require('colors');
-var env = require('./env');
-var getPlansFromConfig = require('./plans');
-var git = require('./git');
-var os = require('os');
-var pkg = require('../package');
-var readConfig = require('./config');
-var semver = require('semver');
-var ci = require('./ci');
-var ui = require('./ui');
-var util = require('./util');
-var version = require('./version');
+const bump = require('./bump');
+const cli = require('./cli');
+const colors = require('colors');
+const env = require('./env');
+const getPlansFromConfig = require('./plans');
+const git = require('./git');
+const os = require('os');
+const pkg = require('../package');
+const readConfig = require('./config');
+const semver = require('semver');
+const ci = require('./ci');
+const ui = require('./ui');
+const util = require('./util');
+const version = require('./version');
 
 function getCurrentVersion(process, program, root, constants) {
   var validation = program.bump
@@ -346,6 +346,7 @@ function run(process) {
       });
     }).catch(function onError(error) {
       console.error('\n  error: %s\n', error.message);
+      // eslint-disable-next-line no-process-exit
       process.exit(1);
     });
 }

--- a/lib/plans.js
+++ b/lib/plans.js
@@ -1,6 +1,6 @@
+/* eslint-disable no-console */
 'use strict';
 
-var env = require('./env');
 var execSync = require('child_process').execSync;
 var os = require('os');
 
@@ -21,7 +21,7 @@ function Command(command) {
   this.command = command;
 }
 
-var commandNumber = 0;
+var globalCommandNumber = 0;
 /**
  * Run the {@link Command}.
  * @private
@@ -30,7 +30,7 @@ var commandNumber = 0;
  * @throws {Error}
  */
 Command.prototype.run = function run(variables) {
-  var thisCommand = commandNumber++;
+  var commandNumber = globalCommandNumber++;
   var env = {};
   if (variables) {
     variables.forEach(function forEachVariable(value, key) {
@@ -39,16 +39,15 @@ Command.prototype.run = function run(variables) {
   }
 
   try {
-    console.log(`executing ${thisCommand}]: "${this.command}"`);
-    console.log('  with env ', env);
+    console.log(`executing ${commandNumber}]: "${this.command}"`);
     execSync(this.command, { env: env,
       stdio: ['ignore', 'ignore', 'ignore'] });
   } catch (error) {
-    console.log(`${thisCommand}] failed with`, error);
+    console.log(`${commandNumber}] failed with`, error);
     throw new Error(this.command.split(' ')[0] +
-      ' exited with code ' + error.code,);
+      ' exited with code ' + error.code);
   }
-}
+};
 
 Command.prototype.toString = function toString() {
   return this.command;

--- a/lib/plans.js
+++ b/lib/plans.js
@@ -21,6 +21,7 @@ function Command(command) {
   this.command = command;
 }
 
+var commandNumber = 0;
 /**
  * Run the {@link Command}.
  * @private
@@ -29,6 +30,7 @@ function Command(command) {
  * @throws {Error}
  */
 Command.prototype.run = function run(variables) {
+  var thisCommand = commandNumber++;
   var env = {};
   if (variables) {
     variables.forEach(function forEachVariable(value, key) {
@@ -37,11 +39,14 @@ Command.prototype.run = function run(variables) {
   }
 
   try {
+    console.log(`executing ${thisCommand}]: "${this.command}"`);
+    console.log('  with env ', env);
     execSync(this.command, { env: env,
       stdio: ['ignore', 'ignore', 'ignore'] });
   } catch (error) {
+    console.log(`${thisCommand}] failed with`, error);
     throw new Error(this.command.split(' ')[0] +
-      ' exited with code ' + error.code);
+      ' exited with code ' + error.code,);
   }
 }
 
@@ -83,7 +88,7 @@ Plan.getPlanFromConfig = function getPlanFromConfig(config, planName) {
 Plan.getPlansFromConfig = function getPlansFromConfig(config) {
   var plans = new Map();
   if (config.plans) {
-    for (var planName in config.plans) 
+    for (var planName in config.plans)
       plans.set(planName, new Plan(config.plans[planName].commands));
   }
   return plans;

--- a/lib/travis.js
+++ b/lib/travis.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var https = require('https');
-var util = require('./util');
 
 function triggerBuild(program) {
   return new Promise(function triggerBuildPromise(resolve, reject) {
@@ -22,6 +21,7 @@ function triggerBuild(program) {
       request: {
         branch: program.branch,
         config: {
+          // eslint-disable-next-line camelcase
           after_success: './node_modules/.bin/release -b ' + program.branch +
             ' -n' +
             (program.publish ? ' -p' : '') +

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "semver": "^5.1.0"
   },
   "devDependencies": {
-    "twilio-release-tool": "https://github.com/twilio/release-tool.git"
+    "twilio-release-tool": "https://github.com/twilio/release-tool.git#JSDK-2528_circleci"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "release-tool",
+  "name": "twilio-release-tool",
   "version": "0.2.3-dev",
-  "description": "Release Tool",
+  "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {
     "release": "./release"
@@ -10,6 +10,7 @@
     "test": "echo \"Warn: no test specified\""
   },
   "keywords": [
+    "circleci",
     "travis",
     "travis-ci",
     "ci",
@@ -28,6 +29,6 @@
     "semver": "^5.1.0"
   },
   "devDependencies": {
-    "release-tool": "https://github.com/twilio/release-tool.git"
+    "twilio-release-tool": "https://github.com/twilio/release-tool.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.8-dev",
+  "version": "0.2.9",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.5",
+  "version": "0.2.5-dev",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.10-dev",
+  "version": "0.2.10",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.3-dev",
+  "version": "0.2.5",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.6-dev",
+  "version": "0.2.8-dev",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.7",
+  "version": "0.2.6-dev",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/markandrus/release-tool.git"
+    "url": "https://github.com/twilio/release-tool.git"
   },
   "dependencies": {
     "colors": "^1.1.2",
@@ -28,6 +28,6 @@
     "semver": "^5.1.0"
   },
   "devDependencies": {
-    "release-tool": "https://github.com/markandrus/release-tool.git"
+    "release-tool": "https://github.com/twilio/release-tool.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.10",
+  "version": "0.2.11-dev",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.5-dev",
+  "version": "0.2.7",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twilio-release-tool",
-  "version": "0.2.9",
+  "version": "0.2.10-dev",
   "description": "Twilio Release Tool",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
This change enables release tool to work with CircleCI. It also moves the releases for the tool itself to circleCI. 

With this change here is a sample release: https://app.circleci.com/pipelines/github/twilio/release-tool/15/workflows/5de34604-d26f-4160-8941-2636a6079640


once merged following downstream PRs will be updated to use the new version:
- webrtc: https://github.com/twilio/twilio-webrtc.js/pull/122
- twilio-video:  https://github.com/twilio/twilio-video.js/pull/1016

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
